### PR TITLE
Fix element ID print in phase correction

### DIFF
--- a/HL Custom Model Checker.tab/Revisar e Corrigir.panel/FASE.pushbutton/script.py
+++ b/HL Custom Model Checker.tab/Revisar e Corrigir.panel/FASE.pushbutton/script.py
@@ -31,7 +31,7 @@ def correct_elem_phase(elem, target_phase_created_id):
         param.Set(target_phase_created_id)  # Define a altura (em metros)
         print(
             "Fase da elemento ID {} corrigida de {} para {}"
-              .format(element.Id, incorrect_phase_created, target_phase_created_id)
+              .format(elem.Id, incorrect_phase_created, target_phase_created_id)
               )
     except Exception as e:
         print("Error: {}".format(e))


### PR DESCRIPTION
## Summary
- fix typo `element` -> `elem` inside `correct_elem_phase`

## Testing
- `python -m py_compile 'HL Custom Model Checker.tab/Revisar e Corrigir.panel/FASE.pushbutton/script.py'`

------
https://chatgpt.com/codex/tasks/task_e_684317b8b7048322a6267f85d7d06cb8